### PR TITLE
Handle null candidate task lists

### DIFF
--- a/src/main/java/com/abada/engine/core/TaskInstance.java
+++ b/src/main/java/com/abada/engine/core/TaskInstance.java
@@ -73,7 +73,8 @@ public class TaskInstance {
     }
 
     public void setCandidateUsers(List<String> candidateUsers) {
-        this.candidateUsers = candidateUsers;
+        // Ensure the internal list is never null to avoid NullPointerExceptions
+        this.candidateUsers = candidateUsers != null ? candidateUsers : new ArrayList<>();
     }
 
     public List<String> getCandidateGroups() {
@@ -81,7 +82,8 @@ public class TaskInstance {
     }
 
     public void setCandidateGroups(List<String> candidateGroups) {
-        this.candidateGroups = candidateGroups;
+        // Ensure the internal list is never null to avoid NullPointerExceptions
+        this.candidateGroups = candidateGroups != null ? candidateGroups : new ArrayList<>();
     }
 
     // Helper methods

--- a/src/main/java/com/abada/engine/core/TaskManager.java
+++ b/src/main/java/com/abada/engine/core/TaskManager.java
@@ -83,8 +83,10 @@ public class TaskManager {
         if (task.getAssignee() != null) {
             return task.getAssignee().equals(user); // direct assignee match
         }
+        // Treat null inputs as empty collections to prevent NullPointerExceptions
+        List<String> userGroups = groups != null ? groups : List.of();
         return task.getCandidateUsers().contains(user) ||
-                groups.stream().anyMatch(task.getCandidateGroups()::contains);
+                userGroups.stream().anyMatch(task.getCandidateGroups()::contains);
     }
 
 

--- a/src/test/java/com/abada/engine/core/TaskManagerTest.java
+++ b/src/test/java/com/abada/engine/core/TaskManagerTest.java
@@ -100,4 +100,23 @@ public class TaskManagerTest {
         assertThat(retrieved.get().getName()).isEqualTo("Validate Invoice");
         assertThat(retrieved.get().isCompleted()).isFalse();
     }
+
+    @Test
+    void testVisibleTasksHandleNullGroupsAndCandidates() {
+        TaskManager taskManager = new TaskManager();
+        String processInstanceId = UUID.randomUUID().toString();
+
+        // Simulate a task loaded from persistence with null candidate lists
+        TaskInstance task = new TaskInstance();
+        task.setId(UUID.randomUUID().toString());
+        task.setProcessInstanceId(processInstanceId);
+        task.setTaskDefinitionKey("t1");
+        task.setCandidateUsers(null);
+        task.setCandidateGroups(null);
+        taskManager.addTask(task);
+
+        // Should not throw when groups parameter is null
+        List<TaskInstance> visible = taskManager.getVisibleTasksForUser("user", null);
+        assertThat(visible).isEmpty();
+    }
 }


### PR DESCRIPTION
## Summary
- avoid NullPointerExceptions when candidate users/groups lists are null
- guard user group input in TaskManager
- add regression test for null candidate lists and groups

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for dev.abada:abada-engine:0.6.1-alpha: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.4 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_6895b7314b04832e9d4e822e03217e4c